### PR TITLE
feat: new styling for tags in blog list

### DIFF
--- a/src/components/atoms/Tags.astro
+++ b/src/components/atoms/Tags.astro
@@ -8,8 +8,8 @@ const { tags, class: className = "text-sm" } = Astro.props;
   tags && Array.isArray(tags) && (
     <ul class={className}>
       {tags.map((tag) => (
-        <li class="bg-gray-100 dark:bg-slate-700 inline-block mr-2 mb-2 py-0.5 px-2">
-          <a href={getPermalink(tag, "tag")}>{tag}</a>
+        <li class="bg-gray-100 dark:bg-slate-800 inline-block mr-2 mb-2 py-0.5 px-2 rounded-lg border-2 border-grey-100 dark:border-slate-600 hover:border-blue-500 dark:hover:border-blue-500">
+          <a href={getPermalink(tag, "tag")}>{tag} 🏷</a>
         </li>
       ))}
     </ul>


### PR DESCRIPTION
Proposal for new tag list styling

Before:
- dark: ![image](https://user-images.githubusercontent.com/11775168/236674640-7450b17b-6b8d-42dd-aa22-6a4538347e43.png)
- light: ![image](https://user-images.githubusercontent.com/11775168/236674671-71476071-2ce6-4bb5-84b9-667d1c70da25.png)

After:
- dark: ![image](https://user-images.githubusercontent.com/11775168/236674708-e8592272-01e6-445b-b87a-6ec574455a5e.png)
- light: ![image](https://user-images.githubusercontent.com/11775168/236674683-6c322ee7-fcdf-44ae-80bd-ff9449f530fc.png)
- hover: ![image](https://user-images.githubusercontent.com/11775168/236674726-e96184e0-a750-4ae8-b477-754b0de8ba65.png)

