### PR TITLE
feat: add experimental progressbar

### DIFF
--- a/src/assets/styles/base.css
+++ b/src/assets/styles/base.css
@@ -75,3 +75,24 @@ pre[class*="astro-code"] button:hover {
   cursor: pointer;
   background-color: rgb(55 65 81);
 }
+
+/* Progressbar indicator */
+/* “Experimental Web Platform Features” flag enabled */
+html {
+	scroll-timeline: --page-scroll block;
+}
+
+@keyframes grow-progress {
+	from { transform: scaleX(0); }
+	to { transform: scaleX(1); }
+}
+
+#progress {
+	width: 100%; 
+  height: 0.3em;
+	background: rgb(68, 81, 101);
+
+	transform-origin: 0 50%;
+	animation: grow-progress auto linear;
+	animation-timeline: --page-scroll;
+}

--- a/src/assets/styles/base.css
+++ b/src/assets/styles/base.css
@@ -76,23 +76,26 @@ pre[class*="astro-code"] button:hover {
   background-color: rgb(55 65 81);
 }
 
+/* Styles for Chrome 115+ */
 /* Progressbar indicator */
 /* “Experimental Web Platform Features” flag enabled */
-html {
-	scroll-timeline: --page-scroll block;
-}
+@supports (scroll-timeline: --page-scroll block) {
+  html {
+    scroll-timeline: --page-scroll block;
+  }
 
-@keyframes grow-progress {
-	from { transform: scaleX(0); }
-	to { transform: scaleX(1); }
-}
+  @keyframes grow-progress {
+    from { transform: scaleX(0); }
+    to { transform: scaleX(1); }
+  }
 
-#progress {
-	width: 100%; 
-  height: 0.3em;
-	background: rgb(68, 81, 101);
+  #progress {
+    width: 100%; 
+    height: 0.3em;
+    background: rgb(68, 81, 101);
 
-	transform-origin: 0 50%;
-	animation: grow-progress auto linear;
-	animation-timeline: --page-scroll;
+    transform-origin: 0 50%;
+    animation: grow-progress auto linear;
+    animation-timeline: --page-scroll;
+  }
 }

--- a/src/components/widgets/Header.astro
+++ b/src/components/widgets/Header.astro
@@ -9,12 +9,16 @@ import {
   getBlogPermalink,
   getHomePermalink,
 } from "~/utils/permalinks";
+const { isBlog  } = Astro.props;
 ---
 
 <header
   class="sticky top-0 z-40 flex-none mx-auto w-full bg-slate-100 md:bg-white/90 dark:bg-slate-800 dark:md:bg-slate-800 md:backdrop-blur-sm border-b dark:border-b-0"
   id="header"
 >
+  {isBlog && (
+    <div id="progress"></div>
+  )}
   <div
     class="py-3 px-3 mx-auto w-full md:flex md:justify-between max-w-6xl md:px-4"
   >

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -7,7 +7,7 @@ const { meta } = Astro.props;
 ---
 
 <Layout {meta}>
-  <Header />
+  <Header isBlog />
   <main>
     <slot />
   </main>


### PR DESCRIPTION
Try Chrome 115+ with the “Experimental Web Platform Features” flag enabled.


https://github.com/hendriknielaender/double-trouble/assets/51416554/b8cb88c3-2e4f-4da6-aa7d-9f5e23516701

Its only applied if the browser has this feature enabled, see here for current support:
https://caniuse.com/?search=animation-timeline



