### PR TITLE
fix: reduce emoji logo size on mobile as it looks quite blurred

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -25,7 +25,7 @@ const meta = {
         <i>double</i>
       </div> the trouble.
     </h2>
-    <div class="-mt-6 text-9xl">🤜🤛</div>
+    <div class="-mt-1 text-4xl md:-mt-6 md:text-9xl">🤜🤛</div>
   </div>
   <HighlightedPosts />
 </Layout>


### PR DESCRIPTION
could confirm this on Samsung Internet and on Chrome Mobile