### PR TITLE
chore: fix image credit link

### DIFF
--- a/data/blog/go-1-21.md
+++ b/data/blog/go-1-21.md
@@ -3,7 +3,7 @@ publishDate: "August 3 2023"
 title: "Go 1.21: Now with More Gopher Power and Less 'Go-tchas'!"
 description: "Explore innovative features, including enhanced map and slice operations, structured logging..."
 image: ~/assets/images/thumbnails/gopher.png
-imageCreditUrl: https://labs.openai.com/
+imageCreditUrl: https://www.midjourney.com/
 tags: [gptpost, update, release, go, golang, code]
 ---
 


### PR DESCRIPTION
even though the version was added through dall-e, the original image is from midjourney so i got the feedback that someone was confused why the source is openai while it looks clearly like midjourney.