### PR TITLE
fix: resize hightlighted posts to better fit the screen

### DIFF
--- a/src/components/blog/Grid.astro
+++ b/src/components/blog/Grid.astro
@@ -4,6 +4,6 @@ import Item from "~/components/blog/GridItem.astro";
 const { posts } = Astro.props;
 ---
 
-<div class="grid gap-6 row-gap-5 md:grid-cols-2 lg:grid-cols-4 -mb-6">
+<div class="grid gap-3 row-gap-3 md:grid-cols-2 lg:grid-cols-4 -mb-6">
   {posts.map((post) => <Item post={post} />)}
 </div>

--- a/src/components/blog/GridItem.astro
+++ b/src/components/blog/GridItem.astro
@@ -11,7 +11,7 @@ const image = await findImage(post.image);
 
 <article class="mb-6 transition">
   <div transition:name={"picture"+post.id}
-    class="relative h-0 pb-[56.25%] lg:h-64 overflow-hidden bg-gray-400 dark:bg-slate-700 rounded shadow-lg mb-6"
+    class="relative h-0 pb-[56.25%] lg:h-52 overflow-hidden bg-gray-400 dark:bg-slate-700 rounded shadow-lg mb-2"
   >
     <a
       href={getPermalink(post.slug, "post")}
@@ -19,14 +19,14 @@ const image = await findImage(post.image);
     >
       <Picture
         src={image}
-        class="object-cover w-full lg:h-64 rounded shadow-lg bg-gray-400 dark:bg-slate-700"
+        class="object-cover w-full lg:h-52 rounded shadow-lg bg-gray-400 dark:bg-slate-700"
         widths={[400, 900]}
         sizes="(max-width: 900px) 400px, 900px"
         alt={post.title}
       />
     </a>
   </div>
-  <h3 transition:name={"title"+post.id} class="mb-2 text-xl font-bold leading-snug sm:text-2xl font-heading">
+  <h3 transition:name={"title"+post.id} class="mb-2 text-m font-bold leading-snug sm:text-m font-heading">
     <a
       href={getPermalink(post.slug, "post")}
       class="hover:text-primary-600 underline underline-offset-4 decoration-1 decoration-dotted transition ease-in duration-200"
@@ -34,7 +34,7 @@ const image = await findImage(post.image);
       {post.title}
     </a>
   </h3>
-  <p class="text-gray-700 dark:text-gray-400">
+  <p class="text-gray-700 dark:text-gray-400 text-m sm:text-xs">
     {post.excerpt || post.description}
   </p>
 </article>

--- a/src/components/blog/HighlightedPosts.astro
+++ b/src/components/blog/HighlightedPosts.astro
@@ -13,12 +13,12 @@ const ids = [
 const posts = await findPostsByIds(ids);
 ---
 
-<section class="px-4 py-16 mx-auto max-w-6xl lg:py-20">
-	<div class="flex flex-col mb-6 lg:justify-between lg:flex-row md:mb-8">
+<section class="px-4 py-4 mx-auto max-w-5xl">
+	<div class="flex flex-col lg:justify-between lg:flex-row md:mb-2">
 		<h2
-			class="max-w-lg mb-2 text-3xl font-bold tracking-tight sm:text-4xl sm:leading-none lg:mb-5 group font-heading"
+			class="max-w-lg text-xl font-bold tracking-tight sm:text-xl sm:leading-none group font-heading"
 		>
-			<span class="inline-block mb-1 sm:mb-4">Highlighted Blogposts:</span>
+			<span class="inline-block mb-1 sm:mb-1">Highlighted Posts:</span>
 		</h2>
 	</div>
 	<Grid posts={posts} />


### PR DESCRIPTION
Before:
![image](https://github.com/hendriknielaender/double-trouble/assets/11775168/77c805dc-5db0-46fd-954c-5ad29666aa3c)
After:
![image](https://github.com/hendriknielaender/double-trouble/assets/11775168/5a2f3c5a-fc4b-4447-8f66-0ce73363c1a4)
