### PR TITLE
fix: improve header button focus in dark-mode

### DIFF
--- a/src/components/core/ToggleTheme.astro
+++ b/src/components/core/ToggleTheme.astro
@@ -4,7 +4,7 @@ import { Icon } from "astro-icon";
 const {
   label = "Toggle between Dark and Light mode",
   class:
-    className = "light:text-gray-500 text-gray-400 light:hover:bg-gray-100 hover:bg-gray-700 focus:outline-none focus:ring-4 light:focus:ring-gray-200 focus:ring-gray-700 rounded-lg text-sm p-2.5 inline-flex items-center",
+    className = "light:text-gray-500 text-gray-400 light:hover:bg-gray-100 hover:bg-gray-700 focus:outline-none focus:ring-4 light:focus:ring-gray-200 focus:ring-gray-900 rounded-lg text-sm p-2.5 inline-flex items-center",
   iconClass = "w-6 h-6",
   iconName = "tabler:sun",
 } = Astro.props;

--- a/src/components/widgets/Header.astro
+++ b/src/components/widgets/Header.astro
@@ -62,7 +62,7 @@ const { isBlog  } = Astro.props;
         <div class="hidden items-center md:flex">
           <ToggleTheme iconClass="w-5 h-5" />
           <a
-            class="light:text-gray-500 text-gray-400 light:hover:bg-gray-100 hover:bg-gray-700 focus:outline-none focus:ring-4 light:focus:ring-gray-200 focus:ring-gray-700 rounded-lg text-sm p-2.5 inline-flex items-center"
+            class="light:text-gray-500 text-gray-400 light:hover:bg-gray-100 hover:bg-gray-700 focus:outline-none focus:ring-4 light:focus:ring-gray-200 focus:ring-gray-900 rounded-lg text-sm p-2.5 inline-flex items-center"
             aria-label="RSS Feed"
             href="/rss.xml"
           >
@@ -70,7 +70,7 @@ const { isBlog  } = Astro.props;
           </a>
           <a
             href="https://github.com/hendriknielaender/double-trouble"
-            class="inline-block light:text-gray-500 text-gray-400 light:hover:bg-gray-100 hover:bg-gray-700 focus:outline-none focus:ring-4 light:focus:ring-gray-200 focus:ring-gray-700 rounded-lg text-sm p-2.5"
+            class="inline-block light:text-gray-500 text-gray-400 light:hover:bg-gray-100 hover:bg-gray-700 focus:outline-none focus:ring-4 light:focus:ring-gray-200 focus:ring-gray-900 rounded-lg text-sm p-2.5"
             aria-label="Double Trouble Github"
           >
             <Icon name="tabler:brand-github" class="w-5 h-5" />


### PR DESCRIPTION
currently in dark mode after clicking one of the buttons:
<img width="171" alt="image" src="https://github.com/hendriknielaender/double-trouble/assets/11775168/a05ec337-6c16-4431-a4fb-24c2ed876e16">

with this change:
<img width="171" alt="image" src="https://github.com/hendriknielaender/double-trouble/assets/11775168/5e23c44f-4a3b-4bf4-a05c-f90d8a1238f1">
