### PR TITLE
fix: codeblock indentation and empty lastline

### DIFF
--- a/src/assets/styles/base.css
+++ b/src/assets/styles/base.css
@@ -57,10 +57,15 @@ code {
 code .line::before {
   content: counter(step);
   counter-increment: step;
+  width: 1.5rem;
   margin-right: 0.8rem;
   display: inline-block;
   text-align: right;
   color: rgba(115, 138, 148, 0.4);
+}
+
+code .line:last-child::before {
+  display: none;
 }
 
 pre[class*="astro-code"] {


### PR DESCRIPTION
Before: 
![image](https://github.com/hendriknielaender/double-trouble/assets/11775168/4e16d4e9-93fb-498d-a359-3f6bc66aa265)


After:
![image](https://github.com/hendriknielaender/double-trouble/assets/11775168/935f6212-13ab-4ba5-9327-36b341cc9341)
