### PR TITLE
Align blogpost images & repair htmx gifs

### DIFF
--- a/data/blog/howto-htmx-astrodb-astrossr.md
+++ b/data/blog/howto-htmx-astrodb-astrossr.md
@@ -35,13 +35,7 @@ A responsive button would change its appearance while the operation is ongoing. 
 this means we want to show a "Confirm" text while the button is ready, and a loading spinner while
 the confirmation is being processed.
 
-<img
-    style="display: block;
-           margin-left: auto;
-           margin-right: auto;"
-  alt="Demonstration of HTMX responsive button"
-src="../../src/assets/images/posts/howto-htmx-astrodb-astrossr/button.gif">
-</img>
+![](../../src/assets/images/posts/howto-htmx-astrodb-astrossr/button.gif)
 
 Htmx automatically adds predefined CSS classes to requesting elements, so with tailwind's
 conditional styles, we can use them to hide and display elements when needed. Instead of the
@@ -74,12 +68,7 @@ astro config:
 Before dynamic content loads, we typically want to display *something*. A basic component will
 have skeletons as the initial content, which then gets replaced after loading.
 
-<img
-    style="display: block;
-           margin-left: auto;
-           margin-right: auto;"
-    src="../../src/assets/images/posts/howto-htmx-astrodb-astrossr/loading-forms.gif">
-</img>
+![](../../src/assets/images/posts/howto-htmx-astrodb-astrossr/loading-forms.gif)
 
 In the static frontend page which holds those skeletons, we can load the form like so:
 ```html
@@ -125,13 +114,7 @@ const { loading, title, location, date, description } = Astro.props
 Giving the user early feedback, by displaying form errors on individual fields, is another
 great way to increase the user experience.
 
-<img
-    style="display: block;
-           margin-left: auto;
-           margin-right: auto;"
-  alt="Demonstration of HTMX responsive button"
-src="../../src/assets/images/posts/howto-htmx-astrodb-astrossr/inline-validation.gif">
-</img>
+![](../../src/assets/images/posts/howto-htmx-astrodb-astrossr/inline-validation.gif)
 
 In the frontend, we trigger the validation on key-up or input change (copy paste actions). Htmx
 conveniently resets the timer if another letter is input early. Using `hx-params`, we make sure to
@@ -168,12 +151,7 @@ if (!parsedInput.success) {
 Once an interaction is submitted, problems can happen. There are many ways to display such
 interactive errors to the user, and one such way is toast messages.
 
-<img
-    style="display: block;
-           margin-left: auto;
-           margin-right: auto;"
-    src="../../src/assets/images/posts/howto-htmx-astrodb-astrossr/toast.gif">
-</img>
+![](../../src/assets/images/posts/howto-htmx-astrodb-astrossr/toast.gif)
 
 The server action can be wrapped in a try-catch block, and the server itself decides that this
 error will be rendered as a toast.
@@ -207,12 +185,7 @@ Shout-out to `thisisthemurph` for the basic concept in his [blog-post](https://d
 View transitions are a modern browser feature, which make it easy to have seamless transitions
 between pages. They make page navigation more smooth, while also hiding a bit of loading time.
 
-<img
-    style="display: block;
-           margin-left: auto;
-           margin-right: auto;"
-    src="../../src/assets/images/posts/howto-htmx-astrodb-astrossr/viewtransition.gif">
-</img>
+![](../../src/assets/images/posts/howto-htmx-astrodb-astrossr/viewtransition.gif)
 
 ```html
 <head>

--- a/src/assets/styles/base.css
+++ b/src/assets/styles/base.css
@@ -15,6 +15,15 @@
   }
 }
 
+/* center images in blogposts */
+article img {
+  margin: 0 auto;
+  display: block;
+  max-width: 100%;
+  height: auto;
+  margin-bottom: 20px;
+}
+
 [astro-icon] > * {
   stroke-width: 1.5;
 }


### PR DESCRIPTION
With small images it becomes apparent that they are not centered. I had tried to work around that with <img> tags in `.md` but that is not really supported in Astro. Worked only locally.

Now images are centered in blogposts which seems like a good default. Didnt become apparent yet because usually our images are huge or we don't use any.

Probably will merge immediately because I'm eager to share the post cc @hendriknielaender 

Before:
![Screenshot 2024-05-28 at 20 34 12](https://github.com/hendriknielaender/double-trouble/assets/11775168/4b0ed155-6fda-4ec6-a017-68a8b868cf84)
After:
![Screenshot 2024-05-28 at 20 34 36](https://github.com/hendriknielaender/double-trouble/assets/11775168/f352d05a-6127-48e6-be6a-4d4c5b8927f8)
