### PR TITLE
fix(best-iac-2023): display weights properly

### DIFF
--- a/src/components/atoms/RankingTable.tsx
+++ b/src/components/atoms/RankingTable.tsx
@@ -386,23 +386,23 @@ function RankingTable() {
           ))}
         </tbody>
       </table>
-      <p>
-        Weights:{" "}
+      <div className="flex">
+        <div className="mr-2">Weights:</div>
         {weights.map((weight) => {
           const color = 600 + weight.Weight * 100;
           return (
             <div key={weight.Name}>
               <button
                 type="button"
-                className={`rounded-full px-2 light:text-blue-100 ${bgColorMap[color]}`}
+                className={`rounded-full px-2 mx-1 rounded-sm light:text-blue-100 ${bgColorMap[color]}`}
                 onClick={() => updateWeight(weight.Name)}
               >
                 {weight.Name}: {weight.Weight}
-              </button>{" "}
+              </button>
             </div>
           );
         })}
-      </p>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
At some point the formatting of the weights got broken. Fixed in this PR :)

Before:
![image](https://github.com/user-attachments/assets/c4ffde2c-7aa4-4cea-b967-f171f183f275)

Now:
![image](https://github.com/user-attachments/assets/fa6ab4c6-6578-48c2-abc3-0a67f40711d3)
