### PR TITLE
fix: remove layout shift of the progress bar

### DIFF
--- a/src/components/widgets/Header.astro
+++ b/src/components/widgets/Header.astro
@@ -16,12 +16,12 @@ const { isBlog  } = Astro.props;
   class="sticky top-0 z-40 flex-none mx-auto w-full light:bg-slate-100 bg-slate-900 light:md:bg-slate-100/80 md:bg-black/40 md:backdrop-blur-sm light:border-b border-b-[1px] light:border-slate-400 border-slate-700"
   id="header"
 >
-  {isBlog && (
-    <div id="progress"></div>
-  )}
   <div
     class="py-3 px-3 mx-auto w-full md:flex md:justify-between max-w-6xl md:px-4"
   >
+     {isBlog && (
+    <div id="progress" class="absolute top-0 left-0"></div>
+    )}
     <div class="flex justify-between">
       <a class="flex items-center" href={getHomePermalink()}>
         <Logo />


### PR DESCRIPTION
Before, when you navigate from the main page to a blog page, there is a layout shift of the menu due to the progress bar.
in blog:
![image](https://github.com/user-attachments/assets/c743498f-802f-4462-9c66-85b60b29b0ed)

on home:
![image](https://github.com/user-attachments/assets/133f6ae5-e586-413f-8a5d-1336a43c5c0d)

With this PR this layout shift is removed, and the bar is placed near the bottom of the border for a hopefully slightly better design:
![image](https://github.com/user-attachments/assets/1d1758e6-7992-42fa-8a70-d9f7ca4510ad)
