### PR TITLE
chore: update impressum with new provider

### DIFF
--- a/src/pages/legal.astro
+++ b/src/pages/legal.astro
@@ -34,18 +34,18 @@ import Picture from "~/components/core/Picture.astro";
         <br />
         Hendrik Nieländer &amp; Felix Brilej
         <br />
-        c/o autorenglück.de
-        <br />Franz-Mehring-Str. 15<br />01237 Dresden
+        c/o AutorenServices.de
+        <br />Birkenallee 24<br />36037 Fulda
       </p>
-      <p>double-trouble@auksas.de</p>
+      <p>doubletroubledevblog@gmail.com</p>
       <br />
       <br />
       <p>
         <em>Verantwortlicher im Sinne des Presserechts (V.i.S.d.P.):</em>
         <br /> Hendrik Nieländer &amp; Felix Brilej
         <br />
-        c/o autorenglück.de
-        <br />Franz-Mehring-Str. 15<br />01237 Dresden
+        c/o AutorenServices.de
+        <br />Birkenallee 24<br />36037 Fulda
       </p>
       <br />
       <br />


### PR DESCRIPTION
Hab den hier genommen für 10€ im Jahr: https://autorenservices.de/impressums-service/

Da anscheinend auch eine Email Pflicht besteht hab ich uns auch einen google Account angelegt in unserem vault: doubletroubledevblog@gmail.com