### PR TITLE
ci: fix linting triggers to run only once in PRs

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -2,6 +2,8 @@ name: Code quality
 
 on:
   push:
+    branches:
+      - main
   pull_request:
     paths-ignore:
       - '**.md'
@@ -18,6 +20,6 @@ jobs:
       - name: Setup Biome
         uses: biomejs/setup-biome@v2
         with:
-          version: latest
+          version: 2.0.6
       - name: Run Biome
         run: biome ci .


### PR DESCRIPTION
Should fix the 2x execution of the linting in PRs:

<img width="597" height="215" alt="image" src="https://github.com/user-attachments/assets/bb678865-d4e8-4377-af00-5f8d3fa9857a" />
